### PR TITLE
Add variable number of players

### DIFF
--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -7,7 +7,7 @@ const cartasEjemplo = [
   "Haz un brindis ridículo. Si no lo haces, tomas 2."
 ]
 
-const Juego = ({ jugadores, onFin }) => {
+const Juego = ({ onFin }) => {
   const [cartaActual, setCartaActual] = useState(0)
 
   const siguienteCarta = () => {

--- a/src/components/NombreJugadores.jsx
+++ b/src/components/NombreJugadores.jsx
@@ -1,7 +1,10 @@
 import { useState } from 'react'
 
+const MAX_JUGADORES = 10
+const MIN_JUGADORES = 2
+
 const NombreJugadores = ({ onContinue }) => {
-  const [nombres, setNombres] = useState(['', '', '']) // Puedes ajustar
+  const [nombres, setNombres] = useState(Array(MIN_JUGADORES).fill(''))
 
   const handleChange = (i, value) => {
     const nuevos = [...nombres]
@@ -9,23 +12,60 @@ const NombreJugadores = ({ onContinue }) => {
     setNombres(nuevos)
   }
 
+  const agregarJugador = () => {
+    if (nombres.length < MAX_JUGADORES) {
+      setNombres([...nombres, ''])
+    }
+  }
+
+  const removerJugador = (index) => {
+    if (nombres.length > MIN_JUGADORES) {
+      setNombres(nombres.filter((_, i) => i !== index))
+    }
+  }
+
+  const tieneMinimo = nombres.filter((n) => n.trim() !== '').length >= MIN_JUGADORES
+
+  const continuar = () => {
+    onContinue(nombres.filter((n) => n.trim() !== ''))
+  }
+
   return (
     <div className="p-4 text-center">
       <h2 className="text-2xl font-bold mb-4">Nombres de jugadores</h2>
       <div className="space-y-2">
         {nombres.map((nombre, i) => (
-          <input
-            key={i}
-            className="border p-2 rounded w-full"
-            placeholder={`Jugador ${i + 1}`}
-            value={nombre}
-            onChange={(e) => handleChange(i, e.target.value)}
-          />
+          <div key={i} className="flex items-center space-x-2">
+            <input
+              className="border p-2 rounded w-full"
+              placeholder={`Jugador ${i + 1}`}
+              value={nombre}
+              onChange={(e) => handleChange(i, e.target.value)}
+            />
+            {nombres.length > MIN_JUGADORES && (
+              <button
+                className="text-red-500 font-bold px-2"
+                onClick={() => removerJugador(i)}
+              >
+                X
+              </button>
+            )}
+          </div>
         ))}
       </div>
+      <div className="flex justify-center space-x-4 mt-4">
+        <button
+          className="bg-blue-600 text-white px-4 py-1 rounded hover:bg-blue-700 disabled:bg-blue-400"
+          onClick={agregarJugador}
+          disabled={nombres.length >= MAX_JUGADORES}
+        >
+          Agregar jugador
+        </button>
+      </div>
       <button
-        className="mt-6 bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700"
-        onClick={() => onContinue(nombres.filter(n => n.trim() !== ''))}
+        className="mt-6 bg-green-600 text-white px-6 py-2 rounded hover:bg-green-700 disabled:bg-green-400"
+        onClick={continuar}
+        disabled={!tieneMinimo}
       >
         Comenzar partida
       </button>


### PR DESCRIPTION
## Summary
- allow 2-10 players in player entry form
- support adding and removing player fields
- ignore unused `jugadores` prop in game component

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6877eee37bfc83299d89a0479078d950