### PR TITLE
Implement random card engine

### DIFF
--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -1,11 +1,5 @@
-import { useState } from 'react'
-
-const cartasEjemplo = [
-  "Toma 2 si alguna vez has dicho 'ya casi llego' estando en la regadera.",
-  "Elige a alguien para tomar contigo, sin preguntar por qué.",
-  "Todos los que usen tenis blancos beben.",
-  "Haz un brindis ridículo. Si no lo haces, tomas 2."
-]
+import { useEffect, useState } from 'react'
+import cartasBase from '../data/cartas'
 
 const fondos = [
   'bg-gradient-to-br from-pink-500 to-fuchsia-600',
@@ -14,12 +8,63 @@ const fondos = [
   'bg-gradient-to-br from-amber-500 to-orange-600',
 ]
 
-const Juego = ({ onFin }) => {
-  const [cartaActual, setCartaActual] = useState(0)
+const barajar = (arr) => {
+  const copia = [...arr]
+  for (let i = copia.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[copia[i], copia[j]] = [copia[j], copia[i]]
+  }
+  return copia
+}
+
+const personalizarCarta = (carta, jugadores) => {
+  let texto = carta
+
+  let indiceJugador = null
+  if (texto.includes('{{player}}')) {
+    indiceJugador = Math.floor(Math.random() * jugadores.length)
+    const nombre = jugadores[indiceJugador]
+    texto = texto.replace(/{{player}}/g, nombre)
+  }
+
+  if (texto.includes('{{other}}')) {
+    const opciones = jugadores
+      .map((_, i) => i)
+      .filter((i) => i !== indiceJugador)
+    const idx = opciones.length
+      ? opciones[Math.floor(Math.random() * opciones.length)]
+      : indiceJugador ?? 0
+    const nombreOtro = jugadores[idx]
+    texto = texto.replace(/{{other}}/g, nombreOtro)
+  }
+
+  texto = texto.replace(/{{all}}/g, 'todos')
+  return texto
+}
+
+const Juego = ({ jugadores, onFin }) => {
+  const [mazo, setMazo] = useState([])
+  const [indice, setIndice] = useState(0)
+  const [textoCarta, setTextoCarta] = useState('')
+
+  useEffect(() => {
+    const disponibles =
+      jugadores.length > 1
+        ? cartasBase
+        : cartasBase.filter((c) => !c.includes('{{other}}'))
+    setMazo(barajar(disponibles))
+    setIndice(0)
+  }, [jugadores])
+
+  useEffect(() => {
+    if (mazo.length > 0 && indice < mazo.length) {
+      setTextoCarta(personalizarCarta(mazo[indice], jugadores))
+    }
+  }, [mazo, indice, jugadores])
 
   const siguienteCarta = () => {
-    if (cartaActual < cartasEjemplo.length - 1) {
-      setCartaActual(cartaActual + 1)
+    if (indice < mazo.length - 1) {
+      setIndice(indice + 1)
     } else {
       onFin()
     }
@@ -28,9 +73,11 @@ const Juego = ({ onFin }) => {
   return (
     <div className="p-4 flex flex-col justify-center items-center text-center min-h-screen">
       <div
-        className={`w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6 transition-colors duration-300 ${fondos[cartaActual % fondos.length]}`}
+        className={`w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6 transition-colors duration-300 ${
+          fondos[indice % fondos.length]
+        }`}
       >
-        <h2 className="text-lg font-medium">{cartasEjemplo[cartaActual]}</h2>
+        <h2 className="text-lg font-medium">{textoCarta}</h2>
       </div>
       <button
         className="bg-purple-600 hover:bg-purple-700 active:scale-95 text-white px-6 py-2 rounded-full shadow-md transition duration-300"
@@ -43,4 +90,3 @@ const Juego = ({ onFin }) => {
 }
 
 export default Juego
-

--- a/src/data/cartas.js
+++ b/src/data/cartas.js
@@ -1,0 +1,14 @@
+const cartas = [
+  '{{player}} toma 2 tragos si alguna vez ha mentido en una cita',
+  '{{player}} y {{other}} intercambian un brindis',
+  'Si {{player}} puede nombrar una bebida en 5 segundos, elige quien bebe',
+  'Todos toman 1 trago por cada {{player}} en la sala',
+  '{{player}} reparte 3 tragos entre {{all}}',
+  'Si {{player}} ha viajado al extranjero, {{other}} bebe 2',
+  '{{player}} cuenta un secreto o bebe 2',
+  '{{all}} brindan por {{player}}',
+  '{{player}} elige a {{other}} para tomar 1',
+  '{{player}} bebe si alguna vez ha llegado tarde a una cita con {{other}}',
+]
+
+export default cartas


### PR DESCRIPTION
## Summary
- add sample card data with placeholders
- implement random deck logic to avoid repeats
- personalize cards with player names

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68780e64ed5083298c869e52ab16547a