### PR TITLE
Add placeholder routes and mode selector

### DIFF
--- a/src/components/Inicio.jsx
+++ b/src/components/Inicio.jsx
@@ -2,12 +2,32 @@ const Inicio = ({ onStart }) => {
   return (
     <div className="flex flex-col items-center justify-center min-h-screen text-center px-4">
       <h1 className="text-5xl font-extrabold tracking-wide mb-8 drop-shadow">DrinkMaster 🍻</h1>
-      <button
-        className="bg-green-500 hover:bg-green-600 active:scale-95 text-white px-8 py-3 rounded-full shadow-lg transition duration-300"
-        onClick={onStart}
-      >
-        ¡Comenzar juego!
-      </button>
+      <div className="space-y-4 w-full max-w-xs">
+        <button
+          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          onClick={onStart}
+        >
+          Modo Clásico
+        </button>
+        <button
+          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          onClick={() => (window.location.href = '/hardcore')}
+        >
+          Modo Hardcore
+        </button>
+        <button
+          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          onClick={() => (window.location.href = '/supervivencia')}
+        >
+          Modo Supervivencia
+        </button>
+        <button
+          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          onClick={() => (window.location.href = '/comunidad')}
+        >
+          Modo Comunidad
+        </button>
+      </div>
     </div>
   )
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,9 +3,17 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.jsx'
 import Dashboard from './pages/dashboard.jsx'
+import Hardcore from './pages/Hardcore.jsx'
+import Supervivencia from './pages/Supervivencia.jsx'
+import Comunidad from './pages/Comunidad.jsx'
 
-const RootComponent =
-  window.location.pathname === '/admin-floren-2025' ? Dashboard : App
+const path = window.location.pathname
+let RootComponent = App
+
+if (path === '/admin-floren-2025') RootComponent = Dashboard
+else if (path === '/hardcore') RootComponent = Hardcore
+else if (path === '/supervivencia') RootComponent = Supervivencia
+else if (path === '/comunidad') RootComponent = Comunidad
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/pages/Comunidad.jsx
+++ b/src/pages/Comunidad.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Comunidad = () => (
+  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
+    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
+    <button
+      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
+      onClick={() => (window.location.href = '/')}
+    >
+      Regresar al inicio
+    </button>
+  </div>
+)
+
+export default Comunidad

--- a/src/pages/Hardcore.jsx
+++ b/src/pages/Hardcore.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Hardcore = () => (
+  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
+    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
+    <button
+      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
+      onClick={() => (window.location.href = '/')}
+    >
+      Regresar al inicio
+    </button>
+  </div>
+)
+
+export default Hardcore

--- a/src/pages/Supervivencia.jsx
+++ b/src/pages/Supervivencia.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Supervivencia = () => (
+  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
+    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
+    <button
+      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
+      onClick={() => (window.location.href = '/')}
+    >
+      Regresar al inicio
+    </button>
+  </div>
+)
+
+export default Supervivencia


### PR DESCRIPTION
## Summary
- add a menu with four game modes on the home screen
- create placeholder pages for Hardcore, Supervivencia and Comunidad
- route to those pages according to `window.location.pathname`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a624c594c8329a60f2d59dbb41d54