### PR TITLE
Add hardcore game mode filtering

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,8 +4,8 @@ import NombreJugadores from './components/NombreJugadores'
 import Juego from './components/Juego'
 import Fin from './components/Fin'
 
-function App({ mode = 'normal' }) {
-  const [fase, setFase] = useState('inicio')
+function App({ mode = 'normal', initialPhase = 'inicio' }) {
+  const [fase, setFase] = useState(initialPhase)
   const [jugadores, setJugadores] = useState([])
 
   const irA = (nuevaFase) => setFase(nuevaFase)

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import NombreJugadores from './components/NombreJugadores'
 import Juego from './components/Juego'
 import Fin from './components/Fin'
 
-function App() {
+function App({ mode = 'normal' }) {
   const [fase, setFase] = useState('inicio')
   const [jugadores, setJugadores] = useState([])
 
@@ -12,7 +12,7 @@ function App() {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
-      {fase === 'inicio' && <Inicio onStart={() => irA('nombres')} />}
+      {fase === 'inicio' && <Inicio onStart={() => irA('nombres')} mode={mode} />}
       {fase === 'nombres' && (
         <NombreJugadores
           onContinue={(nombres) => {
@@ -25,6 +25,7 @@ function App() {
         <Juego
           jugadores={jugadores}
           onFin={() => irA('fin')}
+          mode={mode}
         />
       )}
       {fase === 'fin' && <Fin onReiniciar={() => irA('inicio')} />}

--- a/src/components/Fin.jsx
+++ b/src/components/Fin.jsx
@@ -1,10 +1,15 @@
 const Fin = ({ onReiniciar }) => {
+  const handleClick = () => {
+    if (onReiniciar) onReiniciar()
+    window.location.href = '/'
+  }
+
   return (
     <div className="flex flex-col items-center justify-center min-h-screen text-center px-4">
       <h1 className="text-3xl font-bold mb-6">¡Fin del juego! 🥳</h1>
       <button
         className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-8 py-3 rounded-full shadow-md transition duration-300"
-        onClick={onReiniciar}
+        onClick={handleClick}
       >
         Volver al inicio
       </button>

--- a/src/components/Inicio.jsx
+++ b/src/components/Inicio.jsx
@@ -1,4 +1,5 @@
-const Inicio = ({ onStart }) => {
+const Inicio = ({ onStart, mode = 'normal' }) => {
+  const startLabel = mode === 'hardcore' ? 'Modo Hardcore' : 'Modo Clásico'
   return (
     <div className="flex flex-col items-center justify-center min-h-screen text-center px-4">
       <h1 className="text-5xl font-extrabold tracking-wide mb-8 drop-shadow">DrinkMaster 🍻</h1>
@@ -7,7 +8,7 @@ const Inicio = ({ onStart }) => {
           className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
           onClick={onStart}
         >
-          Modo Clásico
+          {startLabel}
         </button>
         <button
           className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"

--- a/src/components/Inicio.jsx
+++ b/src/components/Inicio.jsx
@@ -10,12 +10,14 @@ const Inicio = ({ onStart, mode = 'normal' }) => {
         >
           {startLabel}
         </button>
-        <button
-          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
-          onClick={() => (window.location.href = '/hardcore')}
-        >
-          Modo Hardcore
-        </button>
+        {mode === 'normal' && (
+          <button
+            className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+            onClick={() => (window.location.href = '/hardcore')}
+          >
+            Modo Hardcore
+          </button>
+        )}
         <button
           className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
           onClick={() => (window.location.href = '/supervivencia')}

--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -20,6 +20,7 @@ const barajar = (arr) => {
 
 const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
   const { cards, loading, error } = useActiveCards(mode)
+  const modeLabel = mode === 'hardcore' ? 'Modo Hardcore' : 'Modo Clásico'
   const [mazo, setMazo] = useState([])
   const [indice, setIndice] = useState(0)
   const [textoCarta, setTextoCarta] = useState('')
@@ -84,7 +85,10 @@ const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
   }
 
   return (
-    <div className="p-4 flex flex-col justify-center items-center text-center min-h-screen">
+    <div className="p-4 flex flex-col justify-center items-center text-center min-h-screen relative">
+      <div className="absolute top-2 left-2 text-xs bg-black/40 px-2 py-1 rounded">
+        {modeLabel}
+      </div>
       <div
         className={`w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6 transition-colors duration-300 ${
           fondos[indice % fondos.length]

--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -18,8 +18,8 @@ const barajar = (arr) => {
   return copia
 }
 
-const Juego = ({ jugadores, onFin }) => {
-  const { cards, loading, error } = useActiveCards()
+const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
+  const { cards, loading, error } = useActiveCards(mode)
   const [mazo, setMazo] = useState([])
   const [indice, setIndice] = useState(0)
   const [textoCarta, setTextoCarta] = useState('')

--- a/src/hooks/useActiveCards.js
+++ b/src/hooks/useActiveCards.js
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react'
 import supabase from '../supabaseClient'
 
-const useActiveCards = () => {
+const useActiveCards = (mode = 'normal') => {
   const [cards, setCards] = useState([])
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState(null)
@@ -14,6 +14,7 @@ const useActiveCards = () => {
         .from('cards')
         .select('content, placeholders')
         .eq('is_active', true)
+        .eq('mode', mode)
 
       if (!error) {
         console.log('Cards fetched successfully:', data)
@@ -27,7 +28,7 @@ const useActiveCards = () => {
     }
 
     fetchCards()
-  }, [])
+  }, [mode])
 
   return { cards, loading, error }
 }

--- a/src/pages/Hardcore.jsx
+++ b/src/pages/Hardcore.jsx
@@ -1,15 +1,6 @@
 import React from 'react'
+import App from '../App.jsx'
 
-const Hardcore = () => (
-  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
-    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
-    <button
-      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
-      onClick={() => (window.location.href = '/')}
-    >
-      Regresar al inicio
-    </button>
-  </div>
-)
+const Hardcore = () => <App mode="hardcore" />
 
 export default Hardcore

--- a/src/pages/Hardcore.jsx
+++ b/src/pages/Hardcore.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import App from '../App.jsx'
 
-const Hardcore = () => <App mode="hardcore" />
+const Hardcore = () => <App mode="hardcore" initialPhase="nombres" />
 
 export default Hardcore


### PR DESCRIPTION
## Summary
- enable fetching cards by mode
- display Hardcore mode using the same flow as Classic
- show correct start label based on selected mode

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a670192548329874897f257a7c512