### PR TITLE
Add in-game player addition

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,9 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const [fase, setFase] = useState(initialPhase)
   const [jugadores, setJugadores] = useState([])
 
+  const agregarJugador = (nombre) =>
+    setJugadores((prev) => [...prev, nombre])
+
   const irA = (nuevaFase) => setFase(nuevaFase)
 
   return (
@@ -25,6 +28,7 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
         <Juego
           jugadores={jugadores}
           onFin={() => irA('fin')}
+          onAddPlayer={agregarJugador}
           mode={mode}
         />
       )}

--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -18,12 +18,14 @@ const barajar = (arr) => {
   return copia
 }
 
-const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
+const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
   const { cards, loading, error } = useActiveCards(mode)
   const modeLabel = mode === 'hardcore' ? 'Modo Hardcore' : 'Modo Clásico'
   const [mazo, setMazo] = useState([])
   const [indice, setIndice] = useState(0)
   const [textoCarta, setTextoCarta] = useState('')
+  const [showAdd, setShowAdd] = useState(false)
+  const [nuevoNombre, setNuevoNombre] = useState('')
 
   useEffect(() => {
     if (!loading) {
@@ -46,6 +48,20 @@ const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
       setIndice(indice + 1)
     } else {
       onFin()
+    }
+  }
+
+  const abrirAgregar = () => {
+    setNuevoNombre('')
+    setShowAdd(true)
+  }
+
+  const confirmarAgregar = () => {
+    const nombre = nuevoNombre.trim()
+    if (nombre) {
+      onAddPlayer(nombre)
+      setShowAdd(false)
+      setNuevoNombre('')
     }
   }
 
@@ -105,6 +121,39 @@ const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
       <div className="mt-4 text-sm text-gray-500">
         Carta {indice + 1} de {mazo.length}
       </div>
+      <button
+        className="absolute bottom-4 right-4 bg-blue-600 hover:bg-blue-700 active:scale-95 text-white px-4 py-2 rounded-full shadow-md transition"
+        onClick={abrirAgregar}
+      >
+        Agregar jugador
+      </button>
+
+      {showAdd && (
+        <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-10">
+          <div className="bg-white text-zinc-900 p-4 rounded-xl w-11/12 max-w-xs">
+            <input
+              className="border border-zinc-300 rounded w-full px-3 py-2 mb-4"
+              placeholder="Nombre del jugador"
+              value={nuevoNombre}
+              onChange={(e) => setNuevoNombre(e.target.value)}
+            />
+            <div className="flex justify-end space-x-2">
+              <button
+                className="px-3 py-1 text-sm text-gray-600"
+                onClick={() => setShowAdd(false)}
+              >
+                Cancelar
+              </button>
+              <button
+                className="px-3 py-1 text-sm bg-green-600 text-white rounded"
+                onClick={confirmarAgregar}
+              >
+                Agregar
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add `agregarJugador` helper in `App` and pass to `Juego`
- implement modal and button in `Juego` to add players during a game

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a76599984832987eb3eb4bb570cac