### PR TITLE
Add responsibility popup on home screen

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import ResponsibilityPopup from './components/ResponsibilityPopup'
 import Inicio from './components/Inicio'
 import NombreJugadores from './components/NombreJugadores'
 import Juego from './components/Juego'
@@ -7,6 +8,7 @@ import Fin from './components/Fin'
 function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const [fase, setFase] = useState(initialPhase)
   const [jugadores, setJugadores] = useState([])
+  const [showPopup, setShowPopup] = useState(true)
 
   const agregarJugador = (nombre) =>
     setJugadores((prev) => [...prev, nombre])
@@ -15,6 +17,9 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
 
   return (
     <div className="min-h-dvh w-screen overflow-hidden bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
+      {showPopup && fase === 'inicio' && (
+        <ResponsibilityPopup onClose={() => setShowPopup(false)} />
+      )}
       {fase === 'inicio' && <Inicio onStart={() => irA('nombres')} mode={mode} />}
       {fase === 'nombres' && (
         <NombreJugadores

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,7 +8,10 @@ import Fin from './components/Fin'
 function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const [fase, setFase] = useState(initialPhase)
   const [jugadores, setJugadores] = useState([])
-  const [showPopup, setShowPopup] = useState(true)
+  const [showPopup, setShowPopup] = useState(() => {
+    const alreadySeen = sessionStorage.getItem('popupSeen') === 'true'
+    return !alreadySeen
+  })
 
   const agregarJugador = (nombre) =>
     setJugadores((prev) => [...prev, nombre])
@@ -18,7 +21,12 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
   return (
     <div className="min-h-dvh w-screen overflow-hidden bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
       {showPopup && fase === 'inicio' && (
-        <ResponsibilityPopup onClose={() => setShowPopup(false)} />
+        <ResponsibilityPopup
+          onClose={() => {
+            sessionStorage.setItem('popupSeen', 'true')
+            setShowPopup(false)
+          }}
+        />
       )}
       {fase === 'inicio' && <Inicio onStart={() => irA('nombres')} mode={mode} />}
       {fase === 'nombres' && (

--- a/src/components/ResponsibilityPopup.jsx
+++ b/src/components/ResponsibilityPopup.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+
+const ResponsibilityPopup = ({ onClose }) => (
+  <div className="fixed inset-0 flex items-center justify-center bg-black/60 z-50">
+    <div className="bg-white text-black max-w-md mx-auto p-6 rounded-lg shadow-lg text-center space-y-4 m-4">
+      <h2 className="text-xl font-bold">¡Bienvenido a DrinkMaster!</h2>
+      <p className="text-sm md:text-base">
+        Este juego está diseñado para mayores de 18 años.
+        Recuerda: el objetivo es divertirse, no perder el control.
+      </p>
+      <p className="text-sm md:text-base">
+        Juega con responsabilidad, respeta tus límites y los de los demás.
+        Si decides participar, hazlo de manera consciente y cuida de tu grupo.
+      </p>
+      <p className="font-semibold">¡Que comience la diversión (con moderación)!</p>
+      <button
+        className="bg-green-500 hover:bg-green-600 text-white px-4 py-2 rounded-full mt-2"
+        onClick={onClose}
+      >
+        Entendido
+      </button>
+    </div>
+  </div>
+)
+
+export default ResponsibilityPopup

--- a/src/components/ResponsibilityPopup.jsx
+++ b/src/components/ResponsibilityPopup.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 const ResponsibilityPopup = ({ onClose }) => (
   <div className="fixed inset-0 flex items-center justify-center bg-black/60 z-50">
-    <div className="bg-white text-black max-w-md mx-auto p-6 rounded-lg shadow-lg text-center space-y-4 m-4">
+    <div className="bg-white text-black w-11/12 max-w-md mx-auto p-6 rounded-lg shadow-lg text-center space-y-4 m-4">
       <h2 className="text-xl font-bold">¡Bienvenido a DrinkMaster!</h2>
       <p className="text-sm md:text-base">
         Este juego está diseñado para mayores de 18 años.


### PR DESCRIPTION
## Summary
- show a responsibility popup when the app first opens on the home screen
- close with "Entendido" and prevent interaction with the page behind
- popup only appears once per session

## Testing
- `npm install` *(fails: registry unavailable)*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687a975acde48329b9a5daca9b3c79af