### PR TITLE
feat: streamline player setup and reuse across modes

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,21 +6,35 @@ import Juego from './components/Juego'
 import Fin from './components/Fin'
 
 function App({ mode = 'normal', initialPhase = 'inicio' }) {
-  const [fase, setFase] = useState(initialPhase)
-  const [jugadores, setJugadores] = useState([])
+  const storedPlayers = JSON.parse(sessionStorage.getItem('players') || '[]')
+  const [jugadores, setJugadores] = useState(storedPlayers)
+  const [fase, setFase] = useState(
+    storedPlayers.length >= 2 ? initialPhase : 'nombres'
+  )
   const [showPopup, setShowPopup] = useState(() => {
     const alreadySeen = sessionStorage.getItem('popupSeen') === 'true'
     return !alreadySeen
   })
 
-  const agregarJugador = (nombre) =>
-    setJugadores((prev) => [...prev, nombre])
+  const actualizarJugadores = (nuevos) => {
+    setJugadores(nuevos)
+    sessionStorage.setItem('players', JSON.stringify(nuevos))
+  }
 
-  const irA = (nuevaFase) => setFase(nuevaFase)
+  const agregarJugador = (nombre) =>
+    actualizarJugadores([...jugadores, nombre])
+
+  const irA = (nuevaFase) => {
+    if (nuevaFase === 'juego' && jugadores.length < 2) {
+      setFase('nombres')
+    } else {
+      setFase(nuevaFase)
+    }
+  }
 
   return (
     <div className="min-h-dvh w-screen overflow-hidden bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
-      {showPopup && fase === 'inicio' && (
+      {showPopup && (
         <ResponsibilityPopup
           onClose={() => {
             sessionStorage.setItem('popupSeen', 'true')
@@ -28,12 +42,12 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
           }}
         />
       )}
-      {fase === 'inicio' && <Inicio onStart={() => irA('nombres')} mode={mode} />}
+      {fase === 'inicio' && <Inicio onStart={() => irA('juego')} mode={mode} />}
       {fase === 'nombres' && (
         <NombreJugadores
           onContinue={(nombres) => {
-            setJugadores(nombres)
-            irA('juego')
+            actualizarJugadores(nombres)
+            irA(initialPhase)
           }}
         />
       )}

--- a/src/pages/Hardcore.jsx
+++ b/src/pages/Hardcore.jsx
@@ -1,6 +1,6 @@
 import React from 'react'
 import App from '../App.jsx'
 
-const Hardcore = () => <App mode="hardcore" initialPhase="nombres" />
+const Hardcore = () => <App mode="hardcore" initialPhase="juego" />
 
 export default Hardcore


### PR DESCRIPTION
## Summary
- save player names in `sessionStorage` and reuse them across sessions
- start with player setup after +18 popup and auto-load players for Classic and Hardcore modes
- ensure games only start when at least two players are present

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894c4a3c6e48329924dcd086dc2cf2b