### PR TITLE
feat: implement survival mode

### DIFF
--- a/src/components/SurvivalConfig.jsx
+++ b/src/components/SurvivalConfig.jsx
@@ -1,0 +1,62 @@
+import { useState } from 'react'
+
+const SurvivalConfig = ({ onStart }) => {
+  const [lives, setLives] = useState(3)
+  const [jokers, setJokers] = useState(3)
+  const [difficulty, setDifficulty] = useState('no tan fácil')
+
+  const handleStart = () => {
+    onStart({
+      lives: Number(lives),
+      jokers: Number(jokers),
+      difficulty,
+    })
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
+      <h2 className="text-2xl font-bold mb-6">Configurar Supervivencia</h2>
+      <div className="space-y-4 w-full max-w-xs">
+        <div>
+          <label className="block mb-1">Número de vidas</label>
+          <input
+            type="number"
+            min="1"
+            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            value={lives}
+            onChange={(e) => setLives(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Número de comodines</label>
+          <input
+            type="number"
+            min="0"
+            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            value={jokers}
+            onChange={(e) => setJokers(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block mb-1">Dificultad</label>
+          <select
+            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            value={difficulty}
+            onChange={(e) => setDifficulty(e.target.value)}
+          >
+            <option value="fácil">fácil</option>
+            <option value="no tan fácil">no tan fácil</option>
+          </select>
+        </div>
+        <button
+          className="w-full bg-green-600 hover:bg-green-700 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          onClick={handleStart}
+        >
+          Continuar
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default SurvivalConfig

--- a/src/components/SurvivalGame.jsx
+++ b/src/components/SurvivalGame.jsx
@@ -1,0 +1,157 @@
+import { useState } from 'react'
+import useTriviaQuestion from '../hooks/useTriviaQuestion'
+
+const categorias = [
+  { label: 'Cine y TV', value: 'cine_y_tv' },
+  { label: 'Cultura General', value: 'cultura_general' },
+  { label: 'Deportes', value: 'deportes' },
+]
+
+const SurvivalGame = ({ players, settings, onFinish }) => {
+  const [playersState, setPlayersState] = useState(
+    players.map((name) => ({
+      name,
+      lives: settings.lives,
+      jokers: settings.jokers,
+      lastCategory: null,
+    })),
+  )
+  const [currentIndex, setCurrentIndex] = useState(0)
+  const [stage, setStage] = useState('choose')
+  const [showOptions, setShowOptions] = useState(false)
+  const [revealed, setRevealed] = useState(false)
+  const { question, loading, error, fetchQuestion } = useTriviaQuestion()
+
+  const currentPlayer = playersState[currentIndex]
+
+  const startQuestion = async (cat) => {
+    const updated = playersState.map((p, i) =>
+      i === currentIndex ? { ...p, lastCategory: cat } : p,
+    )
+    setPlayersState(updated)
+    setShowOptions(false)
+    setRevealed(false)
+    setStage('question')
+    const ok = await fetchQuestion(cat, settings.difficulty)
+    if (!ok) {
+      onFinish()
+    }
+  }
+
+  const useJoker = () => {
+    if (!currentPlayer || currentPlayer.jokers <= 0 || showOptions) return
+    const updated = playersState.map((p, i) =>
+      i === currentIndex ? { ...p, jokers: p.jokers - 1 } : p,
+    )
+    setPlayersState(updated)
+    setShowOptions(true)
+  }
+
+  const handleResult = (correct) => {
+    let updated = playersState.map((p, i) => {
+      if (i !== currentIndex) return p
+      const newLives = correct ? p.lives : p.lives - 1
+      return { ...p, lives: newLives }
+    })
+    updated = updated.filter((p) => p.lives > 0)
+    const eliminated = !updated.some((p) => p.name === currentPlayer.name)
+    if (updated.length <= 1) {
+      setPlayersState(updated)
+      onFinish()
+      return
+    }
+    let nextIndex
+    if (eliminated) {
+      nextIndex = currentIndex >= updated.length ? 0 : currentIndex
+    } else {
+      nextIndex = (currentIndex + 1) % updated.length
+    }
+    setPlayersState(updated)
+    setCurrentIndex(nextIndex)
+    setStage('choose')
+  }
+
+  if (!currentPlayer) return null
+
+  return (
+    <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh">
+      <div className="mb-4">
+        <h2 className="text-xl font-bold">Turno de {currentPlayer.name}</h2>
+        <p>
+          Vidas: {currentPlayer.lives} | Comodines: {currentPlayer.jokers}
+        </p>
+      </div>
+      {stage === 'choose' && (
+        <div className="space-y-4 w-full max-w-xs">
+          {categorias.map((cat) => (
+            <button
+              key={cat.value}
+              className="w-full bg-purple-600 hover:bg-purple-700 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 disabled:bg-purple-400"
+              onClick={() => startQuestion(cat.value)}
+              disabled={currentPlayer.lastCategory === cat.value}
+            >
+              {cat.label}
+            </button>
+          ))}
+        </div>
+      )}
+      {stage === 'question' && (
+        <div className="w-full max-w-md">
+          {loading && <p>Cargando pregunta...</p>}
+          {error && <p>Error al cargar pregunta</p>}
+          {question && (
+            <div className="space-y-4">
+              <h3 className="text-lg font-medium">{question.question}</h3>
+              {showOptions && (
+                <ul className="text-left list-disc list-inside">
+                  {question.options.map((opt, i) => (
+                    <li key={i}>{opt}</li>
+                  ))}
+                </ul>
+              )}
+              {!showOptions && currentPlayer.jokers > 0 && (
+                <button
+                  className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
+                  onClick={useJoker}
+                >
+                  Usar comodín ({currentPlayer.jokers})
+                </button>
+              )}
+              {!revealed && (
+                <button
+                  className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md"
+                  onClick={() => setRevealed(true)}
+                >
+                  Mostrar respuesta
+                </button>
+              )}
+              {revealed && (
+                <div className="space-y-2">
+                  <p className="font-semibold">
+                    Respuesta: {question.answer}
+                  </p>
+                  <div className="flex justify-center space-x-4">
+                    <button
+                      className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
+                      onClick={() => handleResult(true)}
+                    >
+                      Acertó
+                    </button>
+                    <button
+                      className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-full shadow-md"
+                      onClick={() => handleResult(false)}
+                    >
+                      Falló
+                    </button>
+                  </div>
+                </div>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SurvivalGame

--- a/src/hooks/useTriviaQuestion.js
+++ b/src/hooks/useTriviaQuestion.js
@@ -1,0 +1,46 @@
+import { useState } from 'react'
+import supabase from '../supabaseClient'
+
+const useTriviaQuestion = () => {
+  const [question, setQuestion] = useState(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState(null)
+  const [pools, setPools] = useState({})
+
+  const fetchQuestion = async (category, difficulty) => {
+    setLoading(true)
+    setQuestion(null)
+    const key = `${category}-${difficulty}`
+    let pool = pools[key] || []
+    if (pool.length === 0) {
+      const { data, error } = await supabase
+        .from('questions_survival')
+        .select('id, question, options, answer')
+        .eq('category', category)
+        .eq('difficulty', difficulty)
+      if (error) {
+        setError(error)
+        setLoading(false)
+        return false
+      }
+      pool = data || []
+    }
+    if (pool.length === 0) {
+      setError(new Error('no questions'))
+      setLoading(false)
+      return false
+    }
+    const index = Math.floor(Math.random() * pool.length)
+    const selected = pool[index]
+    const remaining = [...pool.slice(0, index), ...pool.slice(index + 1)]
+    setPools({ ...pools, [key]: remaining })
+    setQuestion(selected)
+    setError(null)
+    setLoading(false)
+    return true
+  }
+
+  return { question, loading, error, fetchQuestion }
+}
+
+export default useTriviaQuestion

--- a/src/pages/Supervivencia.jsx
+++ b/src/pages/Supervivencia.jsx
@@ -1,15 +1,42 @@
-import React from 'react'
+import { useState } from 'react'
+import SurvivalConfig from '../components/SurvivalConfig'
+import NombreJugadores from '../components/NombreJugadores'
+import SurvivalGame from '../components/SurvivalGame'
+import Fin from '../components/Fin'
 
-const Supervivencia = () => (
-  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
-    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
-    <button
-      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
-      onClick={() => (window.location.href = '/')}
-    >
-      Regresar al inicio
-    </button>
-  </div>
-)
+const Supervivencia = () => {
+  const [phase, setPhase] = useState('config')
+  const [settings, setSettings] = useState(null)
+  const [players, setPlayers] = useState([])
+
+  return (
+    <div className="min-h-dvh bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
+      {phase === 'config' && (
+        <SurvivalConfig
+          onStart={(cfg) => {
+            setSettings(cfg)
+            setPhase('nombres')
+          }}
+        />
+      )}
+      {phase === 'nombres' && (
+        <NombreJugadores
+          onContinue={(nombres) => {
+            setPlayers(nombres)
+            setPhase('juego')
+          }}
+        />
+      )}
+      {phase === 'juego' && (
+        <SurvivalGame
+          players={players}
+          settings={settings}
+          onFinish={() => setPhase('fin')}
+        />
+      )}
+      {phase === 'fin' && <Fin />}
+    </div>
+  )
+}
 
 export default Supervivencia


### PR DESCRIPTION
## Summary
- add configuration screen and gameplay flow for Survival mode
- fetch trivia questions by category and difficulty from Supabase
- track lives, jokers, category restrictions and question exhaustion per player

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6894d0767c288329b474ac2fd2aa7149