### PR TITLE
style: enhance survival question screen

### DIFF
--- a/src/components/SurvivalGame.jsx
+++ b/src/components/SurvivalGame.jsx
@@ -21,6 +21,9 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
   const [stage, setStage] = useState('choose')
   const [showOptions, setShowOptions] = useState(false)
   const [revealed, setRevealed] = useState(false)
+  const [feedback, setFeedback] = useState(null)
+  const [lifeAnim, setLifeAnim] = useState(false)
+  const [jokerAnim, setJokerAnim] = useState(false)
   const { question, loading, error, fetchQuestion } = useTriviaQuestion()
 
   const currentPlayer = playersState[currentIndex]
@@ -53,13 +56,19 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
     )
     setPlayersState(updated)
     setShowOptions(true)
+    setJokerAnim(true)
+    setTimeout(() => setJokerAnim(false), 600)
   }
 
-  const handleResult = (correct) => {
+  const processResult = (correct) => {
     let eliminatedPlayer = null
     let updated = playersState.map((p, i) => {
       if (i !== currentIndex) return p
       const newLives = correct ? p.lives : p.lives - 1
+      if (newLives < p.lives) {
+        setLifeAnim(true)
+        setTimeout(() => setLifeAnim(false), 600)
+      }
       if (newLives <= 0) eliminatedPlayer = p.name
       return { ...p, lives: newLives }
     })
@@ -90,6 +99,14 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
     setStage('choose')
   }
 
+  const handleResult = (correct) => {
+    setFeedback(correct ? 'correct' : 'wrong')
+    setTimeout(() => {
+      processResult(correct)
+      setFeedback(null)
+    }, 600)
+  }
+
   if (!currentPlayer) return null
 
   if (stage === 'question' && loading) {
@@ -114,19 +131,30 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
   }
 
   return (
-    <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh">
-      <div className="mb-4">
-        <h2 className="text-xl font-bold">Turno de {currentPlayer.name}</h2>
-        <p>
-          Vidas: {currentPlayer.lives} | Comodines: {currentPlayer.jokers}
-        </p>
+    <div
+      className={`p-4 flex flex-col items-center text-center min-h-dvh ${
+        feedback === 'correct' ? 'animate-flash bg-green-500/20' : ''
+      } ${feedback === 'wrong' ? 'animate-shake bg-red-500/20' : ''}`}
+    >
+      <div className="mb-6 flex flex-col items-center">
+        <h2 className="text-xl font-bold mb-2">Turno de {currentPlayer.name}</h2>
+        <div className="flex gap-6 text-lg">
+          <div className={`flex items-center gap-1 ${lifeAnim ? 'animate-pop' : ''}`}>
+            <span>❤️</span>
+            <span>{currentPlayer.lives}</span>
+          </div>
+          <div className={`flex items-center gap-1 ${jokerAnim ? 'animate-flash' : ''}`}>
+            <span>🃏</span>
+            <span>{currentPlayer.jokers}</span>
+          </div>
+        </div>
       </div>
       {stage === 'choose' && (
         <div className="space-y-4 w-full max-w-xs">
           {categorias.map((cat) => (
             <button
               key={cat.value}
-              className="w-full bg-purple-600 hover:bg-purple-700 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 disabled:bg-purple-400"
+              className="w-full bg-purple-600 hover:bg-purple-700 text-white px-6 py-3 rounded-full shadow-lg disabled:bg-purple-400"
               onClick={() => startQuestion(cat.value)}
               disabled={currentPlayer.lastCategory === cat.value}
             >
@@ -140,11 +168,17 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
           <div className="space-y-4">
             <h3 className="text-lg font-medium">{question.question}</h3>
             {showOptions && (
-              <ul className="text-left list-disc list-inside">
+              <div className="grid gap-2">
                 {question.options.map((opt, i) => (
-                  <li key={i}>{opt}</li>
+                  <button
+                    key={i}
+                    disabled
+                    className="w-full bg-purple-700/40 hover:bg-purple-700/60 text-white px-4 py-2 rounded-lg shadow-md cursor-default"
+                  >
+                    {opt}
+                  </button>
                 ))}
-              </ul>
+              </div>
             )}
             {!showOptions && currentPlayer.jokers > 0 && (
               <button
@@ -168,7 +202,7 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
                 {question.explanation && (
                   <p className="text-sm italic">{question.explanation}</p>
                 )}
-                <div className="flex justify-center space-x-4">
+                <div className="flex justify-center gap-4">
                   <button
                     className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
                     onClick={() => handleResult(true)}

--- a/src/components/SurvivalResults.jsx
+++ b/src/components/SurvivalResults.jsx
@@ -1,8 +1,57 @@
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 
 const SurvivalResults = ({ ranking = [] }) => {
+  const [stage, setStage] = useState(0)
+
+  useEffect(() => {
+    const timers = [
+      setTimeout(() => setStage(1), 0),
+      setTimeout(() => setStage(2), 1000),
+      setTimeout(() => setStage(3), 2000),
+      setTimeout(() => setStage(4), 3000),
+    ]
+    return () => timers.forEach(clearTimeout)
+  }, [])
+
   const handleClick = () => {
     window.location.href = '/'
+  }
+
+  if (stage === 1 && ranking[2]) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
+        <p className="text-xl animate-fade-in">
+          <span className="mr-2">🥉</span>
+          {ranking[2]}
+        </p>
+      </div>
+    )
+  }
+
+  if (stage === 2 && ranking[1]) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
+        <p className="text-2xl animate-fade-in">
+          <span className="mr-2">🥈</span>
+          {ranking[1]}
+        </p>
+      </div>
+    )
+  }
+
+  if (stage === 3 && ranking[0]) {
+    return (
+      <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
+        <p className="text-3xl font-bold text-yellow-300 animate-flash">
+          <span className="mr-2">🌟</span>
+          {ranking[0]}
+        </p>
+      </div>
+    )
+  }
+
+  if (stage < 4) {
+    return <div className="flex items-center justify-center min-h-dvh" />
   }
 
   return (

--- a/src/index.css
+++ b/src/index.css
@@ -13,3 +13,44 @@ body,
     @apply transition-all duration-300 ease-in-out active:scale-95 hover:scale-105;
   }
 }
+
+@layer utilities {
+  @keyframes flash {
+    0%, 100% {
+      opacity: 0;
+    }
+    50% {
+      opacity: 1;
+    }
+  }
+  @keyframes shake {
+    0%, 100% {
+      transform: translateX(0);
+    }
+    25% {
+      transform: translateX(-4px);
+    }
+    75% {
+      transform: translateX(4px);
+    }
+  }
+  @keyframes pop {
+    from {
+      transform: scale(1);
+      opacity: 1;
+    }
+    to {
+      transform: scale(0.8);
+      opacity: 0;
+    }
+  }
+  .animate-flash {
+    animation: flash 0.6s ease-in-out;
+  }
+  .animate-shake {
+    animation: shake 0.6s ease-in-out;
+  }
+  .animate-pop {
+    animation: pop 0.6s forwards;
+  }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,16 @@ body,
       opacity: 0;
     }
   }
+  @keyframes fade-in {
+    from {
+      opacity: 0;
+      transform: scale(0.9);
+    }
+    to {
+      opacity: 1;
+      transform: scale(1);
+    }
+  }
   .animate-flash {
     animation: flash 0.6s ease-in-out;
   }
@@ -52,5 +62,8 @@ body,
   }
   .animate-pop {
     animation: pop 0.6s forwards;
+  }
+  .animate-fade-in {
+    animation: fade-in 0.6s ease-out;
   }
 }


### PR DESCRIPTION
## Summary
- center and polish survival mode question layout with icons and option cards
- add subtle animations for correct/incorrect answers, life loss and joker usage

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894eb03db188329b4b6e10034e1e707