### PR TITLE
Improve UI polish with color-coded modes and animations

### DIFF
--- a/src/components/Fin.jsx
+++ b/src/components/Fin.jsx
@@ -5,13 +5,16 @@ const Fin = ({ onReiniciar }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
-      <h1 className="text-3xl font-bold mb-6">¡Fin del juego! 🥳</h1>
+    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4 animate-fade-zoom">
+      <h1 className="text-5xl font-extrabold mb-8 bg-gradient-to-r from-pink-500 to-yellow-500 bg-clip-text text-transparent animate-fade-in">
+        ¡Fin del juego! 🎉
+      </h1>
       <button
-        className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-8 py-3 rounded-full shadow-md transition duration-300"
+        className="mt-4 flex items-center gap-2 bg-purple-600 hover:bg-purple-700 active:scale-95 text-white px-8 py-4 rounded-full shadow-lg transition duration-300 animate-fade-in-up"
         onClick={handleClick}
       >
-        Volver al inicio
+        <span className="text-xl">🏠</span>
+        Regresar al inicio
       </button>
     </div>
   )

--- a/src/components/Inicio.jsx
+++ b/src/components/Inicio.jsx
@@ -1,33 +1,57 @@
 const Inicio = ({ onStart, mode = 'normal' }) => {
   const startLabel = mode === 'hardcore' ? 'Modo Hardcore' : 'Modo Clásico'
+  const startType = mode === 'hardcore' ? 'hardcore' : 'classic'
+
+  const styles = {
+    classic: 'bg-emerald-500 hover:bg-emerald-600',
+    hardcore: 'bg-red-500 hover:bg-red-600',
+    survival: 'bg-amber-500 hover:bg-amber-600',
+    community: 'bg-blue-500 hover:bg-blue-600',
+  }
+
+  const icons = {
+    classic: '🍹',
+    hardcore: '🔥',
+    survival: '🛡️',
+    community: '🤝',
+  }
+
   return (
-    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
+    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4 animate-fade-zoom">
       <h1 className="text-5xl font-extrabold tracking-wide mb-8 drop-shadow">DrinkMaster 🍻</h1>
       <div className="space-y-4 w-full max-w-xs">
         <button
-          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          className={`w-full ${styles[startType]} active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 animate-fade-in-up`}
+          style={{ animationDelay: '100ms' }}
           onClick={onStart}
         >
+          <span className="mr-2">{icons[startType]}</span>
           {startLabel}
         </button>
         {mode === 'normal' && (
           <button
-            className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+            className={`w-full ${styles.hardcore} active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 animate-fade-in-up`}
+            style={{ animationDelay: '200ms' }}
             onClick={() => (window.location.href = '/hardcore')}
           >
+            <span className="mr-2">{icons.hardcore}</span>
             Modo Hardcore
           </button>
         )}
         <button
-          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          className={`w-full ${styles.survival} active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 animate-fade-in-up`}
+          style={{ animationDelay: mode === 'normal' ? '300ms' : '200ms' }}
           onClick={() => (window.location.href = '/supervivencia')}
         >
+          <span className="mr-2">{icons.survival}</span>
           Modo Supervivencia
         </button>
         <button
-          className="w-full bg-green-500 hover:bg-green-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          className={`w-full ${styles.community} active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300 animate-fade-in-up`}
+          style={{ animationDelay: mode === 'normal' ? '400ms' : '300ms' }}
           onClick={() => (window.location.href = '/comunidad')}
         >
+          <span className="mr-2">{icons.community}</span>
           Modo Comunidad
         </button>
       </div>

--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -71,7 +71,7 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
   // Show loading state
   if (loading) {
     return (
-      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh">
+      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh animate-fade-zoom">
         <div className="bg-gray-500 w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6">
           <h2 className="text-lg font-medium">Cargando cartas...</h2>
         </div>
@@ -82,7 +82,7 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
   // Show error state
   if (error) {
     return (
-      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh">
+      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh animate-fade-zoom">
         <div className="bg-red-500 w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6">
           <h2 className="text-lg font-medium">Error al cargar las cartas</h2>
           <p className="text-sm mt-2">{error.message}</p>
@@ -94,7 +94,7 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
   // Show empty state
   if (mazo.length === 0) {
     return (
-      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh">
+      <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh animate-fade-zoom">
         <div className="bg-yellow-500 w-full max-w-md text-white rounded-xl shadow-xl p-6 mb-6">
           <h2 className="text-lg font-medium">No hay cartas disponibles</h2>
           <p className="text-sm mt-2">Necesitas agregar cartas a la base de datos</p>
@@ -104,7 +104,7 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
   }
 
   return (
-    <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh relative">
+    <div className="p-4 flex flex-col justify-center items-center text-center min-h-dvh relative animate-fade-zoom">
       <div className="absolute top-2 left-2 text-xs bg-black/40 px-2 py-1 rounded">
         {modeLabel}
       </div>

--- a/src/components/NombreJugadores.jsx
+++ b/src/components/NombreJugadores.jsx
@@ -31,7 +31,7 @@ const NombreJugadores = ({ onContinue }) => {
   }
 
   return (
-    <div className="p-4 text-center max-w-md mx-auto flex flex-col items-center justify-center min-h-dvh">
+    <div className="p-4 text-center max-w-md mx-auto flex flex-col items-center justify-center min-h-dvh animate-fade-zoom">
       <h2 className="text-2xl font-bold mb-6">Nombres de jugadores</h2>
       <div className="space-y-3">
         {nombres.map((nombre, i) => (

--- a/src/components/NombreJugadores.jsx
+++ b/src/components/NombreJugadores.jsx
@@ -32,19 +32,19 @@ const NombreJugadores = ({ onContinue }) => {
 
   return (
     <div className="p-4 text-center max-w-md mx-auto flex flex-col items-center justify-center min-h-dvh animate-fade-zoom">
-      <h2 className="text-2xl font-bold mb-6">Nombres de jugadores</h2>
-      <div className="space-y-3">
+      <h2 className="text-3xl font-bold mb-6 drop-shadow">Nombres de jugadores</h2>
+      <div className="space-y-4 w-full">
         {nombres.map((nombre, i) => (
-          <div key={i} className="flex items-center space-x-2">
+          <div key={i} className="flex items-center gap-2">
             <input
-              className="border border-zinc-300 rounded px-3 py-2 w-full text-zinc-900"
+              className="w-full px-4 py-2 rounded-full bg-white/90 shadow-inner text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
               placeholder={`Jugador ${i + 1}`}
               value={nombre}
               onChange={(e) => handleChange(i, e.target.value)}
             />
             {nombres.length > MIN_JUGADORES && (
               <button
-                className="text-red-500 font-bold px-2 hover:text-red-600 transition"
+                className="text-red-500 font-bold px-3 hover:text-red-600 transition"
                 onClick={() => removerJugador(i)}
               >
                 ✕
@@ -53,21 +53,19 @@ const NombreJugadores = ({ onContinue }) => {
           </div>
         ))}
       </div>
-      <div className="flex justify-center space-x-4 mt-6">
-        <button
-          className="bg-blue-600 hover:bg-blue-700 active:scale-95 disabled:bg-blue-400 text-white px-4 py-2 rounded transition"
-          onClick={agregarJugador}
-          disabled={nombres.length >= MAX_JUGADORES}
-        >
-          Añadir jugador
-        </button>
-      </div>
       <button
-        className="mt-8 bg-green-600 hover:bg-green-700 active:scale-95 disabled:bg-green-400 text-white px-6 py-3 rounded-full transition w-full"
+        className="mt-6 w-full bg-blue-600 hover:bg-blue-700 active:scale-95 disabled:bg-blue-400 text-white px-5 py-2 rounded-full shadow-md transition flex items-center justify-center gap-2"
+        onClick={agregarJugador}
+        disabled={nombres.length >= MAX_JUGADORES}
+      >
+        ➕ Añadir jugador
+      </button>
+      <button
+        className="mt-8 w-full bg-green-600 hover:bg-green-700 active:scale-95 disabled:bg-green-400 text-white px-6 py-3 rounded-full shadow-lg transition flex items-center justify-center gap-2"
         onClick={continuar}
         disabled={!tieneMinimo}
       >
-        ¡Comenzar partida!
+        🚀 ¡Comenzar partida!
       </button>
     </div>
   )

--- a/src/components/SurvivalConfig.jsx
+++ b/src/components/SurvivalConfig.jsx
@@ -14,33 +14,33 @@ const SurvivalConfig = ({ onStart }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
-      <h2 className="text-2xl font-bold mb-6">Configurar Supervivencia</h2>
-      <div className="space-y-4 w-full max-w-xs">
+    <div className="p-4 text-center max-w-md mx-auto flex flex-col items-center justify-center min-h-dvh animate-fade-zoom">
+      <h2 className="text-3xl font-bold mb-6 drop-shadow">Configurar Supervivencia</h2>
+      <div className="space-y-4 w-full">
         <div>
-          <label className="block mb-1">Número de vidas</label>
+          <label className="block mb-1 ml-2 text-left">Número de vidas</label>
           <input
             type="number"
             min="1"
-            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            className="w-full px-4 py-2 rounded-full bg-white/90 shadow-inner text-zinc-900 focus:outline-none focus:ring-2 focus:ring-purple-500"
             value={lives}
             onChange={(e) => setLives(e.target.value)}
           />
         </div>
         <div>
-          <label className="block mb-1">Número de comodines</label>
+          <label className="block mb-1 ml-2 text-left">Número de comodines</label>
           <input
             type="number"
             min="0"
-            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            className="w-full px-4 py-2 rounded-full bg-white/90 shadow-inner text-zinc-900 focus:outline-none focus:ring-2 focus:ring-purple-500"
             value={jokers}
             onChange={(e) => setJokers(e.target.value)}
           />
         </div>
         <div>
-          <label className="block mb-1">Dificultad</label>
+          <label className="block mb-1 ml-2 text-left">Dificultad</label>
           <select
-            className="w-full border border-zinc-300 text-zinc-900 px-3 py-2 rounded"
+            className="w-full px-4 py-2 rounded-full bg-white/90 shadow-inner text-zinc-900 focus:outline-none focus:ring-2 focus:ring-purple-500"
             value={difficulty}
             onChange={(e) => setDifficulty(e.target.value)}
           >
@@ -49,10 +49,10 @@ const SurvivalConfig = ({ onStart }) => {
           </select>
         </div>
         <button
-          className="w-full bg-green-600 hover:bg-green-700 active:scale-95 text-white px-6 py-3 rounded-full shadow-lg transition duration-300"
+          className="w-full bg-green-600 hover:bg-green-700 text-white px-6 py-3 rounded-full shadow-lg transition"
           onClick={handleStart}
         >
-          Continuar
+          🚀 Continuar
         </button>
       </div>
     </div>

--- a/src/components/SurvivalGame.jsx
+++ b/src/components/SurvivalGame.jsx
@@ -7,6 +7,13 @@ const categorias = [
   { label: 'Deportes', value: 'deportes' },
 ]
 
+const fondos = [
+  'bg-gradient-to-br from-pink-500 to-fuchsia-600',
+  'bg-gradient-to-br from-emerald-500 to-lime-500',
+  'bg-gradient-to-br from-sky-500 to-indigo-500',
+  'bg-gradient-to-br from-amber-500 to-orange-600',
+]
+
 const SurvivalGame = ({ players, settings, onFinish }) => {
   const [playersState, setPlayersState] = useState(
     players.map((name) => ({
@@ -24,6 +31,7 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
   const [feedback, setFeedback] = useState(null)
   const [lifeAnim, setLifeAnim] = useState(false)
   const [jokerAnim, setJokerAnim] = useState(false)
+  const [questionCount, setQuestionCount] = useState(-1)
   const { question, loading, error, fetchQuestion } = useTriviaQuestion()
 
   const currentPlayer = playersState[currentIndex]
@@ -47,6 +55,7 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
       }
       return
     }
+    setQuestionCount((prev) => prev + 1)
   }
 
   const useJoker = () => {
@@ -174,61 +183,67 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
         </div>
       )}
       {stage === 'question' && question && (
-        <div className="w-full max-w-md">
-          <div className="space-y-4">
-            <h3 className="text-lg font-medium">{question.question}</h3>
+        <div className="w-full max-w-md flex flex-col items-center">
+          <div
+            className={`w-full text-white rounded-xl shadow-xl p-6 mb-6 ${fondos[(questionCount >= 0 ? questionCount : 0) % fondos.length]}`}
+          >
+            <h3 className="text-lg font-medium break-words">{question.question}</h3>
             {showOptions && (
-              <div className="grid gap-2">
+              <div className="mt-4 grid gap-2">
                 {question.options.map((opt, i) => (
                   <button
                     key={i}
                     disabled
-                    className="w-full bg-purple-700/40 hover:bg-purple-700/60 text-white px-4 py-2 rounded-lg shadow-md cursor-default"
+                    className="w-full bg-white/20 text-white px-4 py-2 rounded-full shadow-md cursor-default"
                   >
                     {opt}
                   </button>
                 ))}
               </div>
             )}
+            {revealed && (
+              <div className="mt-4 space-y-2">
+                <p className="font-semibold">Respuesta: {question.answer}</p>
+                {question.explanation && (
+                  <p className="text-sm italic">{question.explanation}</p>
+                )}
+              </div>
+            )}
+          </div>
+          <div className="w-full flex flex-col gap-3">
             {!showOptions && currentPlayer.jokers > 0 && (
               <button
-                className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
+                className="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
                 onClick={useJoker}
               >
-                Usar comodín ({currentPlayer.jokers})
+                🃏 Usar comodín ({currentPlayer.jokers})
               </button>
             )}
             {!revealed && (
               <button
-                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md"
+                className="w-full bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md"
                 onClick={() => setRevealed(true)}
               >
                 Mostrar respuesta
               </button>
             )}
-            {revealed && (
-              <div className="space-y-2">
-                <p className="font-semibold">Respuesta: {question.answer}</p>
-                {question.explanation && (
-                  <p className="text-sm italic">{question.explanation}</p>
-                )}
-                <div className="flex justify-center gap-4">
-                  <button
-                    className="bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
-                    onClick={() => handleResult(true)}
-                  >
-                    Acertó
-                  </button>
-                  <button
-                    className="bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-full shadow-md"
-                    onClick={() => handleResult(false)}
-                  >
-                    Falló
-                  </button>
-                </div>
-              </div>
-            )}
           </div>
+          {revealed && (
+            <div className="w-full flex flex-col gap-3">
+              <button
+                className="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
+                onClick={() => handleResult(true)}
+              >
+                Acertó
+              </button>
+              <button
+                className="w-full bg-red-600 hover:bg-red-700 text-white px-4 py-2 rounded-full shadow-md"
+                onClick={() => handleResult(false)}
+              >
+                Falló
+              </button>
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/SurvivalGame.jsx
+++ b/src/components/SurvivalGame.jsx
@@ -211,7 +211,7 @@ const SurvivalGame = ({ players, settings, onFinish }) => {
             )}
           </div>
           <div className="w-full flex flex-col gap-3">
-            {!showOptions && currentPlayer.jokers > 0 && (
+            {!showOptions && !revealed && currentPlayer.jokers > 0 && (
               <button
                 className="w-full bg-green-600 hover:bg-green-700 text-white px-4 py-2 rounded-full shadow-md"
                 onClick={useJoker}

--- a/src/components/SurvivalResults.jsx
+++ b/src/components/SurvivalResults.jsx
@@ -55,17 +55,20 @@ const SurvivalResults = ({ ranking = [] }) => {
   }
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4">
-      <h1 className="text-3xl font-bold mb-6">Podio Final 🏆</h1>
-      <ol className="w-full max-w-md mb-6 space-y-2">
+    <div className="flex flex-col items-center justify-center min-h-dvh text-center px-4 animate-fade-zoom">
+      <h1 className="text-5xl font-extrabold mb-8 bg-gradient-to-r from-pink-500 to-yellow-500 bg-clip-text text-transparent animate-fade-in">
+        ¡Podio Final! 🏆
+      </h1>
+      <ol className="w-full max-w-md mb-8 space-y-3">
         {ranking.map((name, idx) => (
           <li
             key={name}
-            className={
+            className={`px-6 py-3 rounded-full shadow-md flex items-center justify-center animate-fade-in-up ${
               idx === 0
-                ? 'text-2xl font-bold text-yellow-300 flex items-center justify-center'
-                : 'text-xl'
-            }
+                ? 'bg-yellow-500/20 text-yellow-300 text-xl font-bold'
+                : 'bg-white/10 text-white'
+            }`}
+            style={{ animationDelay: `${idx * 100}ms` }}
           >
             {idx === 0 && <span className="mr-2">🌟</span>}
             {idx === 1 && <span className="mr-2">🥈</span>}
@@ -76,10 +79,11 @@ const SurvivalResults = ({ ranking = [] }) => {
         ))}
       </ol>
       <button
-        className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-8 py-3 rounded-full shadow-md transition duration-300"
+        className="mt-4 flex items-center gap-2 bg-purple-600 hover:bg-purple-700 text-white px-8 py-4 rounded-full shadow-lg transition duration-300 animate-fade-in-up"
         onClick={handleClick}
       >
-        Volver al inicio
+        <span className="text-xl">🏠</span>
+        Regresar al inicio
       </button>
     </div>
   )


### PR DESCRIPTION
## Summary
- Color-code start screen buttons with mode-specific icons and entry animations
- Redesign game end screen with gradient heading, animated return button, and fade-in effect
- Apply subtle fade transitions across key screens for smoother navigation

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894f4f220e483298e0a213f5aeb445c