### PR TITLE
feat: global player editing modal

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import Inicio from './components/Inicio'
 import NombreJugadores from './components/NombreJugadores'
 import Juego from './components/Juego'
 import Fin from './components/Fin'
+import EditarJugadoresPopup from './components/EditarJugadoresPopup'
 
 function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const storedPlayers = JSON.parse(sessionStorage.getItem('players') || '[]')
@@ -11,6 +12,7 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const [fase, setFase] = useState(
     storedPlayers.length >= 2 ? initialPhase : 'nombres'
   )
+  const [showEdit, setShowEdit] = useState(false)
   const [showPopup, setShowPopup] = useState(() => {
     const alreadySeen = sessionStorage.getItem('popupSeen') === 'true'
     return !alreadySeen
@@ -20,9 +22,6 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
     setJugadores(nuevos)
     sessionStorage.setItem('players', JSON.stringify(nuevos))
   }
-
-  const agregarJugador = (nombre) =>
-    actualizarJugadores([...jugadores, nombre])
 
   const irA = (nuevaFase) => {
     if (nuevaFase === 'juego' && jugadores.length < 2) {
@@ -55,11 +54,31 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
         <Juego
           jugadores={jugadores}
           onFin={() => irA('fin')}
-          onAddPlayer={agregarJugador}
           mode={mode}
         />
       )}
       {fase === 'fin' && <Fin onReiniciar={() => irA('inicio')} />}
+
+      {fase !== 'nombres' && (
+        <>
+          <button
+            className="fixed bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg text-xl"
+            onClick={() => setShowEdit(true)}
+          >
+            ✏️
+          </button>
+          {showEdit && (
+            <EditarJugadoresPopup
+              players={jugadores}
+              onClose={() => setShowEdit(false)}
+              onSave={(nombres) => {
+                actualizarJugadores(nombres)
+                setShowEdit(false)
+              }}
+            />
+          )}
+        </>
+      )}
     </div>
   )
 }

--- a/src/components/EditarJugadoresPopup.jsx
+++ b/src/components/EditarJugadoresPopup.jsx
@@ -31,8 +31,8 @@ const EditarJugadoresPopup = ({ players, onClose, onSave }) => {
   }
 
   return (
-    <div className="fixed inset-0 flex items-center justify-center bg-black/60 z-50 animate-fade-in">
-      <div className="bg-white text-zinc-900 w-11/12 max-w-md mx-auto p-6 rounded-lg shadow-lg m-4 animate-fade-zoom">
+    <div className="fixed inset-0 flex items-center justify-center bg-black/60 backdrop-blur-sm z-50 animate-fade-in">
+      <div className="w-11/12 max-w-md mx-auto p-6 rounded-lg shadow-lg m-4 animate-fade-zoom bg-zinc-900/90 text-white backdrop-blur-md border border-white/10">
         <h2 className="text-xl font-bold text-center mb-4">Editar jugadores</h2>
         <div className="space-y-4">
           {nombres.map((nombre, i) => (
@@ -62,7 +62,7 @@ const EditarJugadoresPopup = ({ players, onClose, onSave }) => {
           ➕ Añadir jugador
         </button>
         <div className="flex justify-end gap-2 mt-6">
-          <button className="px-4 py-2 text-sm text-gray-600" onClick={onClose}>
+          <button className="px-4 py-2 text-sm text-gray-300 hover:text-white" onClick={onClose}>
             Cancelar
           </button>
           <button

--- a/src/components/EditarJugadoresPopup.jsx
+++ b/src/components/EditarJugadoresPopup.jsx
@@ -1,0 +1,82 @@
+import { useState } from 'react'
+
+const MAX_JUGADORES = 10
+const MIN_JUGADORES = 2
+
+const EditarJugadoresPopup = ({ players, onClose, onSave }) => {
+  const [nombres, setNombres] = useState(players)
+
+  const handleChange = (i, value) => {
+    const nuevos = [...nombres]
+    nuevos[i] = value
+    setNombres(nuevos)
+  }
+
+  const agregarJugador = () => {
+    if (nombres.length < MAX_JUGADORES) {
+      setNombres([...nombres, ''])
+    }
+  }
+
+  const removerJugador = (index) => {
+    if (nombres.length > MIN_JUGADORES) {
+      setNombres(nombres.filter((_, i) => i !== index))
+    }
+  }
+
+  const tieneMinimo = nombres.filter((n) => n.trim() !== '').length >= MIN_JUGADORES
+
+  const guardar = () => {
+    onSave(nombres.filter((n) => n.trim() !== ''))
+  }
+
+  return (
+    <div className="fixed inset-0 flex items-center justify-center bg-black/60 z-50 animate-fade-in">
+      <div className="bg-white text-zinc-900 w-11/12 max-w-md mx-auto p-6 rounded-lg shadow-lg m-4 animate-fade-zoom">
+        <h2 className="text-xl font-bold text-center mb-4">Editar jugadores</h2>
+        <div className="space-y-4">
+          {nombres.map((nombre, i) => (
+            <div key={i} className="flex items-center gap-2">
+              <input
+                className="w-full px-4 py-2 rounded-full bg-white/90 shadow-inner text-zinc-900 placeholder-zinc-400 focus:outline-none focus:ring-2 focus:ring-purple-500"
+                placeholder={`Jugador ${i + 1}`}
+                value={nombre}
+                onChange={(e) => handleChange(i, e.target.value)}
+              />
+              {nombres.length > MIN_JUGADORES && (
+                <button
+                  className="text-red-500 font-bold px-3 hover:text-red-600 transition"
+                  onClick={() => removerJugador(i)}
+                >
+                  ✕
+                </button>
+              )}
+            </div>
+          ))}
+        </div>
+        <button
+          className="mt-6 w-full bg-blue-600 hover:bg-blue-700 active:scale-95 disabled:bg-blue-400 text-white px-5 py-2 rounded-full shadow-md transition flex items-center justify-center gap-2"
+          onClick={agregarJugador}
+          disabled={nombres.length >= MAX_JUGADORES}
+        >
+          ➕ Añadir jugador
+        </button>
+        <div className="flex justify-end gap-2 mt-6">
+          <button className="px-4 py-2 text-sm text-gray-600" onClick={onClose}>
+            Cancelar
+          </button>
+          <button
+            className="px-4 py-2 bg-green-600 hover:bg-green-700 active:scale-95 disabled:bg-green-400 text-white rounded-full transition"
+            onClick={guardar}
+            disabled={!tieneMinimo}
+          >
+            Guardar
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default EditarJugadoresPopup
+

--- a/src/components/Juego.jsx
+++ b/src/components/Juego.jsx
@@ -20,14 +20,12 @@ const barajar = (arr) => {
   return copia
 }
 
-const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
+const Juego = ({ jugadores, onFin, mode = 'normal' }) => {
   const { cards, loading, error } = useActiveCards(mode)
   const modeLabel = mode === 'hardcore' ? 'Modo Hardcore' : 'Modo Clásico'
   const [mazo, setMazo] = useState([])
   const [indice, setIndice] = useState(0)
   const [textoCarta, setTextoCarta] = useState('')
-  const [showAdd, setShowAdd] = useState(false)
-  const [nuevoNombre, setNuevoNombre] = useState('')
 
   useEffect(() => {
     if (!loading) {
@@ -54,19 +52,6 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
     }
   }
 
-  const abrirAgregar = () => {
-    setNuevoNombre('')
-    setShowAdd(true)
-  }
-
-  const confirmarAgregar = () => {
-    const nombre = nuevoNombre.trim()
-    if (nombre) {
-      onAddPlayer(nombre)
-      setShowAdd(false)
-      setNuevoNombre('')
-    }
-  }
 
   // Show loading state
   if (loading) {
@@ -122,39 +107,6 @@ const Juego = ({ jugadores, onFin, onAddPlayer, mode = 'normal' }) => {
       >
         Siguiente
       </button>
-      <button
-        className="absolute bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-full shadow-md"
-        onClick={abrirAgregar}
-      >
-        Agregar jugador
-      </button>
-
-      {showAdd && (
-        <div className="absolute inset-0 bg-black/60 flex items-center justify-center z-10 animate-fade-in">
-          <div className="bg-white text-zinc-900 p-4 rounded-xl w-11/12 max-w-xs animate-fade-zoom">
-            <input
-              className="border border-zinc-300 rounded w-full px-3 py-2 mb-4"
-              placeholder="Nombre del jugador"
-              value={nuevoNombre}
-              onChange={(e) => setNuevoNombre(e.target.value)}
-            />
-            <div className="flex justify-end space-x-2">
-              <button
-                className="px-3 py-1 text-sm text-gray-600"
-                onClick={() => setShowAdd(false)}
-              >
-                Cancelar
-              </button>
-              <button
-                className="px-3 py-1 text-sm bg-green-600 text-white rounded"
-                onClick={confirmarAgregar}
-              >
-                Agregar
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add global pencil button to edit players after setup
- refactor game to rely on shared player state
- implement modal with animations and styling for editing players

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6895331ad1f08329b8170a32dfc201de