### PR TITLE
feat: show edit players button across all screens

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ import Inicio from './components/Inicio'
 import NombreJugadores from './components/NombreJugadores'
 import Juego from './components/Juego'
 import Fin from './components/Fin'
-import EditarJugadoresPopup from './components/EditarJugadoresPopup'
+import EditarJugadoresButton from './components/EditarJugadoresButton'
 
 function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const storedPlayers = JSON.parse(sessionStorage.getItem('players') || '[]')
@@ -12,7 +12,6 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
   const [fase, setFase] = useState(
     storedPlayers.length >= 2 ? initialPhase : 'nombres'
   )
-  const [showEdit, setShowEdit] = useState(false)
   const [showPopup, setShowPopup] = useState(() => {
     const alreadySeen = sessionStorage.getItem('popupSeen') === 'true'
     return !alreadySeen
@@ -59,25 +58,11 @@ function App({ mode = 'normal', initialPhase = 'inicio' }) {
       )}
       {fase === 'fin' && <Fin onReiniciar={() => irA('inicio')} />}
 
-      {fase !== 'nombres' && (
-        <>
-          <button
-            className="fixed bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg text-xl"
-            onClick={() => setShowEdit(true)}
-          >
-            ✏️
-          </button>
-          {showEdit && (
-            <EditarJugadoresPopup
-              players={jugadores}
-              onClose={() => setShowEdit(false)}
-              onSave={(nombres) => {
-                actualizarJugadores(nombres)
-                setShowEdit(false)
-              }}
-            />
-          )}
-        </>
+      {fase !== 'nombres' && fase !== 'fin' && (
+        <EditarJugadoresButton
+          players={jugadores}
+          onPlayersChange={actualizarJugadores}
+        />
       )}
     </div>
   )

--- a/src/components/EditarJugadoresButton.jsx
+++ b/src/components/EditarJugadoresButton.jsx
@@ -1,0 +1,33 @@
+import { useState } from 'react'
+import EditarJugadoresPopup from './EditarJugadoresPopup'
+
+const EditarJugadoresButton = ({ players = [], onPlayersChange }) => {
+  const [showEdit, setShowEdit] = useState(false)
+
+  const handleSave = (nombres) => {
+    sessionStorage.setItem('players', JSON.stringify(nombres))
+    if (onPlayersChange) onPlayersChange(nombres)
+    setShowEdit(false)
+  }
+
+  return (
+    <>
+      <button
+        className="fixed bottom-4 right-4 bg-blue-600 hover:bg-blue-700 text-white p-3 rounded-full shadow-lg text-xl"
+        onClick={() => setShowEdit(true)}
+      >
+        ✏️
+      </button>
+      {showEdit && (
+        <EditarJugadoresPopup
+          players={players}
+          onClose={() => setShowEdit(false)}
+          onSave={handleSave}
+        />
+      )}
+    </>
+  )
+}
+
+export default EditarJugadoresButton
+

--- a/src/pages/Comunidad.jsx
+++ b/src/pages/Comunidad.jsx
@@ -1,15 +1,24 @@
-import React from 'react'
-
-const Comunidad = () => (
-  <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
-    <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
-    <button
-      className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
-      onClick={() => (window.location.href = '/')}
-    >
-      Regresar al inicio
-    </button>
-  </div>
-)
+import { useState } from 'react'
+import EditarJugadoresButton from '../components/EditarJugadoresButton'
+const Comunidad = () => {
+  const [players, setPlayers] = useState(
+    JSON.parse(sessionStorage.getItem('players') || '[]'),
+  )
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white flex flex-col items-center justify-center text-center p-4">
+      <h1 className="text-2xl font-bold mb-6">Estamos trabajando para traerte más modos de juego.</h1>
+      <button
+        className="bg-blue-500 hover:bg-blue-600 active:scale-95 text-white px-6 py-3 rounded-full shadow-md transition"
+        onClick={() => (window.location.href = '/')}
+      >
+        Regresar al inicio
+      </button>
+      <EditarJugadoresButton
+        players={players}
+        onPlayersChange={setPlayers}
+      />
+    </div>
+  )
+}
 
 export default Comunidad

--- a/src/pages/Supervivencia.jsx
+++ b/src/pages/Supervivencia.jsx
@@ -2,12 +2,15 @@ import { useState } from 'react'
 import SurvivalConfig from '../components/SurvivalConfig'
 import SurvivalGame from '../components/SurvivalGame'
 import SurvivalResults from '../components/SurvivalResults'
+import EditarJugadoresButton from '../components/EditarJugadoresButton'
 
 const Supervivencia = () => {
   const [phase, setPhase] = useState('config')
   const [settings, setSettings] = useState(null)
   const [results, setResults] = useState([])
-  const players = JSON.parse(sessionStorage.getItem('players') || '[]')
+  const [players, setPlayers] = useState(
+    JSON.parse(sessionStorage.getItem('players') || '[]'),
+  )
 
   return (
     <div className="min-h-dvh bg-gradient-to-br from-fuchsia-900 via-purple-900 to-indigo-900 text-white">
@@ -30,6 +33,12 @@ const Supervivencia = () => {
         />
       )}
       {phase === 'fin' && <SurvivalResults ranking={results} />}
+      {phase !== 'fin' && (
+        <EditarJugadoresButton
+          players={players}
+          onPlayersChange={setPlayers}
+        />
+      )}
     </div>
   )
 }

--- a/src/pages/dashboard.jsx
+++ b/src/pages/dashboard.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from 'react'
 import supabase from '../supabaseClient'
+import EditarJugadoresButton from '../components/EditarJugadoresButton'
 
 const Dashboard = () => {
   const [cards, setCards] = useState([])
@@ -19,6 +20,9 @@ const Dashboard = () => {
     mode: '',
     is_active: true,
   })
+  const [players, setPlayers] = useState(
+    JSON.parse(sessionStorage.getItem('players') || '[]'),
+  )
 
   const fetchCards = async () => {
     setLoading(true)
@@ -263,6 +267,10 @@ const Dashboard = () => {
           Agregar carta
         </button>
       </form>
+      <EditarJugadoresButton
+        players={players}
+        onPlayersChange={setPlayers}
+      />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- replace per-page logic with reusable EditarJugadoresButton component
- display edit players button in survival, community, and dashboard pages
- hide edit players button on final results and initial players screen

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68954f5534288329aa1f6af11471ae4f